### PR TITLE
Makefile/Installation improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,10 +34,10 @@ config.js::
 
 install:: config.js
 	chmod a+x openjscad
-	scp openjscad ${BIN}
+	cp openjscad ${BIN}
 	#test -d ${LIB} || mkdir ${LIB}
 	mkdir -p ${LIB}
-	scp *.js ${LIB}
+	cp *.js ${LIB}
 	
 deinstall::
 	rm -f ${LIB}/csg.js ${LIB}/openscad.js

--- a/Makefile
+++ b/Makefile
@@ -34,14 +34,13 @@ config.js::
 
 install:: config.js
 	chmod a+x openjscad
-	sudo scp openjscad ${BIN}
-	#sudo test -d ${LIB} || mkdir ${LIB}
-	sudo mkdir -p ${LIB}
-	sudo scp *.js ${LIB}
+	scp openjscad ${BIN}
+	#test -d ${LIB} || mkdir ${LIB}
+	mkdir -p ${LIB}
+	scp *.js ${LIB}
 	
 deinstall::
-	sudo rm -f ${LIB}/csg.js ${LIB}/openscad.js
-	sudo 
+	rm -f ${LIB}/csg.js ${LIB}/openscad.js
 
 # --- developers only below
 

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,9 @@ JSCONF   = config.js
 EXEC_PRE = openjscad.proto
 EXEC_FIN = openjscad
 
+CENT     = central
+CENT_URL = git@github.com:Spiritdude/OpenSCAD.jscad.git
+
 all::
 	@echo "make install clean tests" 
 
@@ -45,8 +48,10 @@ deinstall::
 # --- developers only below
 
 github::	clean
-	git remote set-url origin git@github.com:Spiritdude/OpenSCAD.jscad.git
-	git push -u origin master
+	git ls-remote ${CENT} >/dev/null            \
+		&& git remote set-url ${CENT} ${CENT_URL} \
+		|| git remote add ${CENT} ${CENT_URL}     
+	git push -u ${CENT} master
 
 dist::	clean
 	cd ..; tar cfz Backup/${NAME}-${VERSION}.tar.gz "--exclude=*.git/*" OpenSCAD.jscad/

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ tests::
 
 clean::
 	cd examples; make clean
-	rm openjscad config.js
+	rm -fv openjscad config.js
 
 config.js::
 		# Gen config | STRIP whitespace > config.js

--- a/openjscad.proto
+++ b/openjscad.proto
@@ -1,9 +1,11 @@
 #!/usr/bin/nodejs
 
+// The folloing variables will be inserted here by the makefile:
+// prefix, lib, bin, name, version, jsconf
+
 // OpenJsCad CLI interface, written by Rene K. Mueller <spiritdude@gmail.com>
 // License: GPLv2
 //
-var version = '0.002';
 //
 // Description:
 //   openjscad <file> [-o <stl>]
@@ -15,9 +17,6 @@ var version = '0.002';
 // 2013/03/02: 0.002: proper installation of the dependencies (csg.js & openscad.js) so openjscad can be used properly
 // 2013/03/01: 0.001: initial version, with base function from openscad.jscad
 //
-
-var lib = '/usr/local/lib/openjscad/';    // for now hard-coded
-
 var fs = require('fs');
 var vm = require('vm');
 //include('./openscad.js');         // later


### PR DESCRIPTION
Introduce compile-time variables (dynamic $LIB!) by injecting variables into the executable usin metaprogramming

Fix some bad style: Do not use sudo in Makefiles, rather invoke the makefile with root privileges. This serves to avoid confusion and permission-scrambeling if installation without  higher permissions is required.

Avoid using scp as it might not be installed everywhere. (Also: What's wrong about good old cp?).

Do not use git/refs/origin for the github target as this can scramble settings for devs who work on forks.
